### PR TITLE
Show README as a rendered markdown file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
+# Change the Narrative Perspective
+
 This project includes two parts: preprocess and mention selection.
 
 The usage of each component is described in the corresponding folder.
 
 The order to use each component is as follows: preprocess, mention selection.
 
-The annotated pov data is in the folder "pov_data".
+The annotated point of view data is in the folder "pov_data".


### PR DESCRIPTION
Hi Mika,  I just changed the README to a markdown file so that it renders accordingly on GitHub.  I did so with minimal change to the content.  If you prefer it this way, I can then do the same for all other README files in the repository.  By the way, kudos for the great work that you've done for your project.